### PR TITLE
Fix broken Azure CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,5 +574,5 @@ Horizon 2020 research and innovation programme under the project ROSIN with the
 grant agreement No 732287. For more information, visit [rosin-project.eu](http://rosin-project.eu/).
 
 
-[ci-badge]: https://img.shields.io/azure-devops/build/zivid-devops/376f5fda-ba80-4d6c-aaaa-cbcd5e0ad6c0/2/master.svg
-[ci-url]: https://dev.azure.com/zivid-devops/zivid-ros/_build/latest?definitionId=1&branchName=master
+[ci-badge]: https://img.shields.io/azure-devops/build/zivid-devops/83f1ca39-6eb0-4fd3-939c-c9cec95a5b26/1/master
+[ci-url]: https://dev.azure.com/zivid-devops/zivid-ros/_build?definitionId=1&_a=summary&repositoryFilter=1&branchFilter=2


### PR DESCRIPTION
In commit 8b53a4d3f7e6 the CI status badge image was changed to using
the wrong project and defintion id's. We incorrectly used zivid-python
id's.

In this commit the correct project id and definition id for zivid-ros
are used. The image URL was created following the guide in
https://shields.io/category/build.

The badge link previously gave 404. It is now updated to point to the
master branch.