### PR TITLE
Update Readme and CI to SDK 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ sudo apt-get install -y python-catkin-tools git
 
 ### Zivid SDK
 
-To use the ROS driver you need to download and install the "Zivid Core" package. Zivid SDK version 2.0, 2.1 and
-2.2 is supported. See [releases](https://github.com/zivid/zivid-ros/releases) for older ROS driver releases that
+To use the ROS driver you need to download and install the "Zivid Core" package. Zivid SDK version 2.0 to 2.3
+is supported. See [releases](https://github.com/zivid/zivid-ros/releases) for older ROS driver releases that
 supports older SDK versions.
 
 Follow [this guide](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/59080712/Zivid+Software+Installation)
@@ -339,8 +339,8 @@ cloud. For more information about HDR capture, visit our
 
 The capture settings available in the `zivid_camera` node matches the settings in the Zivid API.
 To become more familiar with the different settings and what they do, see the API reference for the
-[Settings](http://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings.html)
-and [Settings2D](http://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D.html)
+[Settings](http://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings.html)
+and [Settings2D](http://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D.html)
 classes, or use Zivid Studio.
 
 The settings can be viewed and configured using [dynamic_reconfigure](https://wiki.ros.org/dynamic_reconfigure).
@@ -401,10 +401,10 @@ In order to capture a point cloud at least one acquisition needs to be enabled.
 | Name                                     | Type   |  Zivid API Setting             |  Note  |
 |------------------------------------------|--------|--------------------------------|--------|
 | `settings/acquisition_<n>/enabled`       | bool   |
-| `settings/acquisition_<n>/aperture`      | double | [Settings::Acquisition::Aperture](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Acquisition_1_1Aperture.html)
-| `settings/acquisition_<n>/brightness`    | double | [Settings::Acquisition::Brightness](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Acquisition_1_1Brightness.html)
-| `settings/acquisition_<n>/exposure_time` | int    | [Settings::Acquisition::ExposureTime](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Acquisition_1_1ExposureTime.html) | Microseconds
-| `settings/acquisition_<n>/gain`          | double | [Settings::Acquisition::Gain](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Acquisition_1_1Gain.html)
+| `settings/acquisition_<n>/aperture`      | double | [Settings::Acquisition::Aperture](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Acquisition_1_1Aperture.html)
+| `settings/acquisition_<n>/brightness`    | double | [Settings::Acquisition::Brightness](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Acquisition_1_1Brightness.html)
+| `settings/acquisition_<n>/exposure_time` | int    | [Settings::Acquisition::ExposureTime](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Acquisition_1_1ExposureTime.html) | Microseconds
+| `settings/acquisition_<n>/gain`          | double | [Settings::Acquisition::Gain](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Acquisition_1_1Gain.html)
 
 #### Processing settings
 
@@ -412,17 +412,17 @@ In order to capture a point cloud at least one acquisition needs to be enabled.
 
 | Name                                                     | Type   |  Zivid API Setting                     |
 |----------------------------------------------------------|--------|----------------------------------------|
-| `settings/processing_color_balance_blue`                 | double | [Settings::Processing::Color::Balance::Blue](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Balance_1_1Blue.html)
-| `settings/processing_color_balance_green`                | double | [Settings::Processing::Color::Balance::Green](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Balance_1_1Green.html)
-| `settings/processing_color_balance_red`                  | double | [Settings::Processing::Color::Balance::Red](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Balance_1_1Red.html)
-| `settings/processing_color_gamma`                        | double | [Settings::Processing::Color::Gamma](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Gamma.html)
-| `settings/processing_filters_noise_removal_enabled`      | bool   | [Settings::Processing::Filters::Noise::Removal::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Noise_1_1Removal_1_1Enabled.html)
-| `settings/processing_filters_noise_removal_threshold`    | double | [Settings::Processing::Filters::Noise::Removal::Threshold](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Noise_1_1Removal_1_1Threshold.html)
-| `settings/processing_filters_outlier_removal_enabled`    | bool   | [Settings::Processing::Filters::Outlier::Removal::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Outlier_1_1Removal_1_1Enabled.html)
-| `settings/processing_filters_outlier_removal_threshold`  | double | [Settings::Processing::Filters::Outlier::Removal::Threshold](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Outlier_1_1Removal_1_1Threshold.html)
-| `settings/processing_filters_reflection_removal_enabled` | bool   | [Settings::Processing::Filters::Reflection::Removal::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Reflection_1_1Removal_1_1Enabled.html)
-| `settings/processing_filters_smoothing_gaussian_enabled` | bool   | [Settings::Processing::Filters::Smoothing::Gaussian::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Smoothing_1_1Gaussian_1_1Enabled.html)
-| `settings/processing_filters_smoothing_gaussian_sigma`   | double | [Settings::Processing::Filters::Smoothing::Gaussian::Sigma](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Smoothing_1_1Gaussian_1_1Sigma.html)
+| `settings/processing_color_balance_blue`                 | double | [Settings::Processing::Color::Balance::Blue](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Balance_1_1Blue.html)
+| `settings/processing_color_balance_green`                | double | [Settings::Processing::Color::Balance::Green](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Balance_1_1Green.html)
+| `settings/processing_color_balance_red`                  | double | [Settings::Processing::Color::Balance::Red](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Balance_1_1Red.html)
+| `settings/processing_color_gamma`                        | double | [Settings::Processing::Color::Gamma](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Gamma.html)
+| `settings/processing_filters_noise_removal_enabled`      | bool   | [Settings::Processing::Filters::Noise::Removal::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Noise_1_1Removal_1_1Enabled.html)
+| `settings/processing_filters_noise_removal_threshold`    | double | [Settings::Processing::Filters::Noise::Removal::Threshold](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Noise_1_1Removal_1_1Threshold.html)
+| `settings/processing_filters_outlier_removal_enabled`    | bool   | [Settings::Processing::Filters::Outlier::Removal::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Outlier_1_1Removal_1_1Enabled.html)
+| `settings/processing_filters_outlier_removal_threshold`  | double | [Settings::Processing::Filters::Outlier::Removal::Threshold](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Outlier_1_1Removal_1_1Threshold.html)
+| `settings/processing_filters_reflection_removal_enabled` | bool   | [Settings::Processing::Filters::Reflection::Removal::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Reflection_1_1Removal_1_1Enabled.html)
+| `settings/processing_filters_smoothing_gaussian_enabled` | bool   | [Settings::Processing::Filters::Smoothing::Gaussian::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Smoothing_1_1Gaussian_1_1Enabled.html)
+| `settings/processing_filters_smoothing_gaussian_sigma`   | double | [Settings::Processing::Filters::Smoothing::Gaussian::Sigma](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Smoothing_1_1Gaussian_1_1Sigma.html)
 
 #### Experimental settings
 
@@ -430,11 +430,12 @@ Note that these settings may be changed, renamed or removed in future SDK releas
 
 | Name                                                                               | Type   |  Zivid API Setting             |
 |------------------------------------------------------------------------------------|--------|--------------------------------|
-| `settings/experimental_engine`                                                     | enum   | [Settings::Experimental::Engine](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Experimental_1_1Engine.html)
-| `settings/processing_filters_experimental_contrast_distortion_correction_enabled`  | bool   | [Settings::Processing::Filters::Experimental::ContrastDistortion::Correction::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Experimental_1_1ContrastDistortion_1_1Correction_1_1Enabled.html)
-| `settings/processing_filters_experimental_contrast_distortion_correction_strength` | double | [Settings::Processing::Filters::Experimental::ContrastDistortion::Correction::Strength](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Experimental_1_1ContrastDistortion_1_1Correction_1_1Strength.html)
-| `settings/processing_filters_experimental_contrast_distortion_removal_enabled`     | bool   | [Settings::Processing::Filters::Experimental::ContrastDistortion::Removal::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Experimental_1_1ContrastDistortion_1_1Removal_1_1Enabled.html)
-| `settings/processing_filters_experimental_contrast_distortion_removal_threshold`   | double | [Settings::Processing::Filters::Experimental::ContrastDistortion::Removal::Threshold](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Experimental_1_1ContrastDistortion_1_1Removal_1_1Threshold.html)
+| `settings/experimental_engine`                                                     | enum   | [Settings::Experimental::Engine](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Experimental_1_1Engine.html)
+| `settings/processing_color_experimental_tone_mapping_enabled` | enum | [Settings::Processing::Color::Experimental::ToneMapping::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Color_1_1Experimental_1_1ToneMapping_1_1Enabled.html)
+| `settings/processing_filters_experimental_contrast_distortion_correction_enabled`  | bool   | [Settings::Processing::Filters::Experimental::ContrastDistortion::Correction::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Experimental_1_1ContrastDistortion_1_1Correction_1_1Enabled.html)
+| `settings/processing_filters_experimental_contrast_distortion_correction_strength` | double | [Settings::Processing::Filters::Experimental::ContrastDistortion::Correction::Strength](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Experimental_1_1ContrastDistortion_1_1Correction_1_1Strength.html)
+| `settings/processing_filters_experimental_contrast_distortion_removal_enabled`     | bool   | [Settings::Processing::Filters::Experimental::ContrastDistortion::Removal::Enabled](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Experimental_1_1ContrastDistortion_1_1Removal_1_1Enabled.html)
+| `settings/processing_filters_experimental_contrast_distortion_removal_threshold`   | double | [Settings::Processing::Filters::Experimental::ContrastDistortion::Removal::Threshold](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings_1_1Processing_1_1Filters_1_1Experimental_1_1ContrastDistortion_1_1Removal_1_1Threshold.html)
 
 
 ### 2D settings
@@ -448,10 +449,10 @@ calling the [capture_2d](#capture_2d) service, otherwise the service will return
 | Name                                      | Type   |  Zivid API Setting             |  Note  |
 |-------------------------------------------|--------|--------------------------------|--------|
 | `settings_2d/acquisition_0/enabled`       | bool   |
-| `settings_2d/acquisition_0/aperture`      | double | [Settings2D::Acquisition::Aperture](https://www.zivid.com/software/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D_1_1Acquisition_1_1Aperture.html)
-| `settings_2d/acquisition_0/brightness`    | double | [Settings2D::Acquisition::Brightness](https://www.zivid.com/software/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D_1_1Acquisition_1_1Brightness.html)
-| `settings_2d/acquisition_0/exposure_time` | int    | [Settings2D::Acquisition::ExposureTime](https://www.zivid.com/software/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D_1_1Acquisition_1_1ExposureTime.html) | Microseconds
-| `settings_2d/acquisition_0/gain`          | double | [Settings2D::Acquisition::Gain](https://www.zivid.com/software/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D_1_1Acquisition_1_1Gain.html)
+| `settings_2d/acquisition_0/aperture`      | double | [Settings2D::Acquisition::Aperture](https://www.zivid.com/software/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D_1_1Acquisition_1_1Aperture.html)
+| `settings_2d/acquisition_0/brightness`    | double | [Settings2D::Acquisition::Brightness](https://www.zivid.com/software/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D_1_1Acquisition_1_1Brightness.html)
+| `settings_2d/acquisition_0/exposure_time` | int    | [Settings2D::Acquisition::ExposureTime](https://www.zivid.com/software/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D_1_1Acquisition_1_1ExposureTime.html) | Microseconds
+| `settings_2d/acquisition_0/gain`          | double | [Settings2D::Acquisition::Gain](https://www.zivid.com/software/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D_1_1Acquisition_1_1Gain.html)
 
 #### Processing settings
 
@@ -459,10 +460,10 @@ calling the [capture_2d](#capture_2d) service, otherwise the service will return
 
 | Name                                         | Type   |  Zivid API Setting                     |
 |----------------------------------------------|--------|----------------------------------------|
-| `settings_2d/processing_color_balance_blue`  | double | [Settings2D::Processing::Color::Balance::Blue](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D_1_1Processing_1_1Color_1_1Balance_1_1Blue.html)
-| `settings_2d/processing_color_balance_green` | double | [Settings2D::Processing::Color::Balance::Green](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D_1_1Processing_1_1Color_1_1Balance_1_1Green.html)
-| `settings_2d/processing_color_balance_red`   | double | [Settings2D::Processing::Color::Balance::Red](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D_1_1Processing_1_1Color_1_1Balance_1_1Red.html)
-| `settings_2d/processing_color_gamma`         | double | [Settings2D::Processing::Color::Gamma](https://www.zivid.com/hubfs/softwarefiles/releases/2.2.0+f0867d62-1/doc/cpp/classZivid_1_1Settings2D_1_1Processing_1_1Color_1_1Gamma.html)
+| `settings_2d/processing_color_balance_blue`  | double | [Settings2D::Processing::Color::Balance::Blue](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D_1_1Processing_1_1Color_1_1Balance_1_1Blue.html)
+| `settings_2d/processing_color_balance_green` | double | [Settings2D::Processing::Color::Balance::Green](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D_1_1Processing_1_1Color_1_1Balance_1_1Green.html)
+| `settings_2d/processing_color_balance_red`   | double | [Settings2D::Processing::Color::Balance::Red](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D_1_1Processing_1_1Color_1_1Balance_1_1Red.html)
+| `settings_2d/processing_color_gamma`         | double | [Settings2D::Processing::Color::Gamma](https://www.zivid.com/hubfs/softwarefiles/releases/2.3.0+a08763f1-1/doc/cpp/classZivid_1_1Settings2D_1_1Processing_1_1Color_1_1Gamma.html)
 
 ## Samples
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ schedules:
     - master
   always: true
 variables:
-  newest_zivid_version: '2.2.0+f0867d62-1'
+  newest_zivid_version: '2.3.0+a08763f1-1'
 stages:
   - stage: Code_Analysis
     jobs:
@@ -33,6 +33,6 @@ stages:
     jobs:
     - template: continuous-integration/azure-pipelines/templates/build_and_test.yml
       parameters:
-        zivid_versions: ['2.0.0+7c4918cf-14', '2.1.0+d2007e12-1']
+        zivid_versions: ['2.0.0+7c4918cf-14', '2.1.0+d2007e12-1', '2.2.0+f0867d62-1']
         ros_distros: ['ros:melodic-ros-base-bionic', 'ros:kinetic-ros-base-xenial']
         compilers: ['g++-7']


### PR DESCRIPTION
We are seeing this issue in the CI quite often:
https://github.com/zivid/zivid-ros/issues/41

Spent some time today looking at it, but was unable to figure out why it fails. It fails even at earlier SDK versions so it still makes sense to update to 2.3.