### PR TITLE
Fix CI failure on Ubuntu 16 due to ROS kinetic being EOL

### DIFF
--- a/continuous-integration/build.sh
+++ b/continuous-integration/build.sh
@@ -19,8 +19,11 @@ do
     catkin list --unformatted | grep -q $package || exit $?
 done
 
+echo "Updating rosdep"
+rosdep update --rosdistro=$ROS_DISTRO || exit $?
+
 echo "Installing dependencies"
-rosdep update && rosdep install --from-paths src --ignore-src -r -y || exit $?
+rosdep install --from-paths src --ignore-src -r -y || exit $?
 
 echo "Building with compiler=$CI_TEST_COMPILER"
 


### PR DESCRIPTION
The CI pipeline for U16 was failing with the error:
zivid_camera: Cannot locate rosdep definition for [image_transport]

The problem is that kinetic has been EOL since May 14th, so rosdep update
would not include this distro. By explicitly setting the --rosdistro argument
in rosdep update we will ensure the current distro is included. It
should also speed up the CI a tiny bit, since we are not updating other
distros.

Fix for issue 43.