### PR TITLE
 Notify Teams channel upon CI failure

### DIFF
--- a/.github/workflows/ROS-commit.yml
+++ b/.github/workflows/ROS-commit.yml
@@ -22,6 +22,11 @@ jobs:
         run: |
           CI_TEST_OS=ros:melodic-ros-base-bionic \
           ./continuous-integration/run_code_analysis_in_docker.sh
+      - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notify_teams.py --status ${{ job.status }}
   build-and-test-newest-zivid:
     name: Build driver and run tests for newest Zivid SDK
     runs-on: ubuntu-latest
@@ -60,7 +65,27 @@ jobs:
           CI_TEST_OS=${{ matrix.os }} \
           CI_TEST_COMPILER=${{ matrix.compiler }} \
           ./continuous-integration/run_build_and_test_in_docker.sh
-
+      - name: Build Status
+        id: build-and-test-newest-status
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        run: echo "::set-output name=result::failure"
+    outputs:
+      build_result: ${{ steps.build-and-test-newest-status.outputs.result }}
+  send-notification-if-build-and-test-newest-zivid-fails: 
+    name: Send Teams notification if build-and-test fails
+    runs-on: ubuntu-latest
+    if: always()
+    needs: build-and-test-newest-zivid
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          lfs: false
+      - name: Notify Teams
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notify_teams.py --status ${{ needs.build-and-test-newest-zivid.outputs.build_result }}
+        if: needs.build-and-test-newest-zivid.outputs.build_result == 'failure'
   build-driver-and-run-tests-for-older-sdk:
     name: Build driver and run tests for older Zivid SDK
     runs-on: ubuntu-latest
@@ -81,3 +106,24 @@ jobs:
           CI_TEST_OS=${{ matrix.ros-distro }} \
           CI_TEST_COMPILER="g++-7" \
           ./continuous-integration/run_build_and_test_in_docker.sh
+      - name: Build Status
+        id: build-and-test-older-status
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        run: echo "::set-output name=result::failure"
+    outputs:
+      build_result: ${{ steps.build-and-test-older-status.outputs.result }}
+  send-notification-if-build-and-test-older-sdk-fails:
+    name: Send Teams notification if build-driver-and-run-tests-for-older-sdk fails
+    runs-on: ubuntu-latest
+    if: always()
+    needs: build-driver-and-run-tests-for-older-sdk
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          lfs: false
+      - name: Notify Teams
+        env:
+          CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
+        run: python continuous-integration/notify_teams.py --status ${{ needs.build-and-test-older-zivid.outputs.build_result }}
+        if: needs.build-and-test-older-zivid.outputs.build_result == 'failure'

--- a/continuous-integration/notify_teams.py
+++ b/continuous-integration/notify_teams.py
@@ -1,0 +1,64 @@
+import argparse
+import os
+import requests
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--status", required=True, help="Job status", type=str)
+    return parser.parse_args()
+
+
+def _main() -> None:
+    args = _args()
+
+    job = os.environ["GITHUB_JOB"]
+    branch = "/".join(os.environ["GITHUB_REF"].split("/")[2:])
+    workflow = os.environ["GITHUB_WORKFLOW"]
+    run_sha = os.environ["GITHUB_SHA"]
+    run_number = os.environ["GITHUB_RUN_NUMBER"]
+
+    server_url = os.environ["GITHUB_SERVER_URL"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    run_id = os.environ["GITHUB_RUN_ID"]
+    workflow_url = f"{server_url}/{repo}/actions/runs/{run_id}"
+    webhook_url = os.environ["CI_FAILURE_TEAMS_HOOK"]
+
+    payload = {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "themeColor": "EC00EC",
+        "summary": f"{job} {args.status} on {branch}",
+        "sections": [
+            {
+                "activityTitle": f"{branch} {args.status}!",
+                "activitySubtitle": f"In workflow '{workflow}', job '{job}'",
+                "facts": [
+                    {"name": "Sha", "value": run_sha},
+                    {"name": "Run", "value": run_number},
+                ],
+            }
+        ],
+        "potentialAction": [
+            {
+                "@type": "ActionCard",
+                "name": "Actions",
+                "actions": [
+                    {
+                        "@type": "OpenUri",
+                        "name": "Go to GitHub Actions",
+                        "targets": [{"os": "default", "uri": workflow_url}],
+                    }
+                ],
+            }
+        ],
+    }
+    request = requests.post(webhook_url, json=payload)
+    try:
+        request.raise_for_status()
+    except requests.HTTPError as ex:
+        raise RuntimeError("Failed to post Teams notification") from ex
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
Notify Teams channel on the `secrets.CI_FAILURE_TEAMS_HOOK` webhook url
if a job in the CI workflow fails.