### PR TITLE
Add support for loading capture settings via YML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ rosrun command:
 ROS_NAMESPACE=zivid_camera rosrun zivid_camera zivid_camera_node _frame_id:=camera1
 ```
 
+`settings_file_path` (string, default: "")
+> Specify the path to a settings `.yml` file. If specified, this file is used to construct the
+> [Zivid Settings](https://www.zivid.com/hubfs/softwarefiles/releases/2.5.0+19fa6891-1/doc/cpp/classZivid_1_1Settings.html#aa6fc7bf87c7a5f672b57397aab01ac3e)
+> and apply them at start up. All calls to the [capture](#capture) service will be made using these settings,
+> unless they are change via e.g. the [capture_assistant/suggest_settings](#capture_assistantsuggest_settings)
+> service.
+
 `file_camera_path` (string, default: "")
 > Specify the path to a file camera to use instead of a real Zivid camera. This can be used to
 > develop without access to hardware. The file camera returns the same point cloud for every capture.
@@ -284,6 +291,11 @@ The connection status is updated by the driver every 10 seconds and before each 
 service call. If the camera is not in `Connected` state the driver will attempt to re-connect to
 the camera when it detects that the camera is available. This can happen if the camera is
 power-cycled or the USB cable is unplugged and then replugged.
+
+### load_settings
+[zivid_camera/LoadSettings.srv](./zivid_camera/srv/LoadSettings.srv)
+
+Loads settings from a `.yml` file and applies them to the Zivid Camera.
 
 ## Topics
 

--- a/zivid_camera/CMakeLists.txt
+++ b/zivid_camera/CMakeLists.txt
@@ -89,6 +89,7 @@ add_service_files(
   CameraInfoModelName.srv
   CameraInfoSerialNumber.srv
   IsConnected.srv
+  LoadSettings.srv
 )
 generate_messages(
   DEPENDENCIES

--- a/zivid_camera/include/auto_generated_include_wrapper.h
+++ b/zivid_camera/include/auto_generated_include_wrapper.h
@@ -17,3 +17,4 @@
 #include <zivid_camera/CameraInfoModelName.h>
 #include <zivid_camera/CameraInfoSerialNumber.h>
 #include <zivid_camera/IsConnected.h>
+#include <zivid_camera/LoadSettings.h>

--- a/zivid_camera/include/zivid_camera.h
+++ b/zivid_camera/include/zivid_camera.h
@@ -48,6 +48,8 @@ private:
                                                      CaptureAssistantSuggestSettings::Response& res);
   void serviceHandlerHandleCameraConnectionLoss();
   bool isConnectedServiceHandler(IsConnected::Request& req, IsConnected::Response& res);
+  bool loadSettingsServiceHandler(LoadSettings::Request& req, LoadSettings::Response&);
+  void loadSettingsFromFile(std::string full_path);
   void publishFrame(Zivid::Frame&& frame);
   bool shouldPublishPointsXYZ() const;
   bool shouldPublishPointsXYZRGBA() const;
@@ -98,6 +100,7 @@ private:
   ros::ServiceServer capture_2d_service_;
   ros::ServiceServer capture_assistant_suggest_settings_service_;
   ros::ServiceServer is_connected_service_;
+  ros::ServiceServer load_settings_service_;
   std::unique_ptr<Capture3DSettingsController> capture_settings_controller_;
   std::unique_ptr<Capture2DSettingsController> capture_2d_settings_controller_;
   Zivid::Application zivid_;

--- a/zivid_camera/src/zivid_camera.cpp
+++ b/zivid_camera/src/zivid_camera.cpp
@@ -215,14 +215,7 @@ ZividCamera::ZividCamera(ros::NodeHandle& nh, ros::NodeHandle& priv)
   if (!settings_file_path.empty())
   {
     ROS_INFO_STREAM("Setting up Capture Setting Controller using file: " << settings_file_path);
-    try
-    {
-      loadSettingsFromFile(settings_file_path);
-    }
-    catch (const std::exception& e)
-    {
-      ROS_WARN_STREAM("Failed to load settings from file " << settings_file_path << ": " << e.what());
-    }
+    loadSettingsFromFile(settings_file_path);
   }
 
   ROS_INFO("Advertising topics");

--- a/zivid_camera/srv/LoadSettings.srv
+++ b/zivid_camera/srv/LoadSettings.srv
@@ -1,0 +1,2 @@
+string full_path
+---


### PR DESCRIPTION
Hello, thanks for making this repository! Here's a PR adding some functionality I thought could be useful.

### Summary
This PR adds the ability to load and apply Zivid Settings via a `.yml` file, both at startup (via a rosparam) and at runtime (via a service).

This probably addresses https://github.com/zivid/zivid-ros/issues/33.

### Risks
1. No tests added for this functionality.
2. Requires a full path to the settings file.
3. Only tested on Zivid Two. I can't say for sure this works as intended on Zivid One since I don't have access to that hardware.
4. Currently, failure to load the `.yml` file at startup is not an error (will not throw), while failure when calling the service is. Maybe you have some preferences on this, please let me know :+1: 