### PR TITLE
Workflows: Notifications not sent to teams

### DIFF
--- a/.github/workflows/ROS-commit.yml
+++ b/.github/workflows/ROS-commit.yml
@@ -63,27 +63,11 @@ jobs:
           CI_TEST_OS=${{ matrix.os }} \
           CI_TEST_COMPILER=${{ matrix.compiler }} \
           ./continuous-integration/run_build_and_test_in_docker.sh
-      - name: Build Status
-        id: build-and-test-newest-status
-        if: ${{ failure() && github.ref == 'refs/heads/master' }}
-        run: echo "::set-output name=result::failure"
-    outputs:
-      build_result: ${{ steps.build-and-test-newest-status.outputs.result }}
-  send-notification-if-build-and-test-newest-zivid-fails:
-    name: Send Teams notification if build-and-test fails
-    runs-on: ubuntu-latest
-    if: always()
-    needs: build-and-test-newest-zivid
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-        with:
-          lfs: false
       - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
         env:
           CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
-        run: python continuous-integration/notify_teams.py --status ${{ needs.build-and-test-newest-zivid.outputs.build_result }}
-        if: needs.build-and-test-newest-zivid.outputs.build_result == 'failure'
+        run: python continuous-integration/notify_teams.py --status ${{ job.status }}
   build-driver-and-run-tests-for-older-sdk:
     name: Build driver and run tests for older Zivid SDK
     runs-on: ubuntu-latest
@@ -103,24 +87,8 @@ jobs:
           CI_TEST_OS=${{ matrix.ros-distro }} \
           CI_TEST_COMPILER="g++-7" \
           ./continuous-integration/run_build_and_test_in_docker.sh
-      - name: Build Status
-        id: build-and-test-older-status
-        if: ${{ failure() && github.ref == 'refs/heads/master' }}
-        run: echo "::set-output name=result::failure"
-    outputs:
-      build_result: ${{ steps.build-and-test-older-status.outputs.result }}
-  send-notification-if-build-and-test-older-sdk-fails:
-    name: Send Teams notification if build-driver-and-run-tests-for-older-sdk fails
-    runs-on: ubuntu-latest
-    if: always()
-    needs: build-driver-and-run-tests-for-older-sdk
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-        with:
-          lfs: false
       - name: Notify Teams
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
         env:
           CI_FAILURE_TEAMS_HOOK: ${{ secrets.CI_FAILURE_TEAMS_HOOK }}
-        run: python continuous-integration/notify_teams.py --status ${{ needs.build-and-test-older-zivid.outputs.build_result }}
-        if: needs.build-and-test-older-zivid.outputs.build_result == 'failure'
+        run: python continuous-integration/notify_teams.py --status ${{ job.status }}


### PR DESCRIPTION
This makes sure failure notifications are reliably sent to the teams channel.

Fixes ZIVID-6429