### PR TITLE
Run ROS-commit workflows on pull requests

### DIFF
--- a/.github/workflows/ROS-commit.yml
+++ b/.github/workflows/ROS-commit.yml
@@ -2,8 +2,9 @@ name: ROS Commit
 # Note: If the workflow name is changed, the CI badge URL in the README must also be updated
 
 on:
-  push:       # Push trigger runs on any pushed branch.
-  schedule:   # Scheduled trigger runs on the latest commit on the default branch.
+  push:           # Push trigger runs on any pushed branch.
+  pull_request:   # Run on new and updated PR's.
+  schedule:      # Scheduled trigger runs on the latest commit on the default branch.
     - cron:  '0 22 * * *'
 
 env:


### PR DESCRIPTION
From https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request:
> Runs your workflow when activity on a pull request in the workflow's
> repository occurs. For example, if no activity types are specified,
> the workflow runs when a pull request is opened or reopened or
> when the head branch of the pull request is updated.