### PR TITLE
CI: install 2024 versions of Intel OCL libraries

### DIFF
--- a/continuous-integration/setup/setup_build_and_test.sh
+++ b/continuous-integration/setup/setup_build_and_test.sh
@@ -36,7 +36,8 @@ function install_opencl_cpu_runtime {
     apt update || exit $?
 
     # Install the OpenCL runtime
-    apt --assume-yes install intel-oneapi-runtime-opencl intel-oneapi-runtime-compilers || exit $?
+    # TODO: remove libxml2 once Intel sorts out its package dependencies
+    apt --assume-yes install libxml2 intel-oneapi-runtime-opencl-2024 intel-oneapi-runtime-compilers-2024 || exit $?
 }
 
 install_opencl_cpu_runtime || exit $?


### PR DESCRIPTION
The intel oneAPI repository was recently updated, which broke our install scripts:

```
The following packages have unmet dependencies:
intel-oneapi-runtime-compilers : Depends: intel-oneapi-runtime-openmp (= 2023.2.2-47) but 2024.0.0-49819 is to be installed
```

Looking at Intel's installation guide:
https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2024-0/apt.html Intel recommends installing a metapackage `intel-oneapi-runtime-libs`. This package now depends on `intel-oneapi-runtime-opencl-2024` and `intel-oneapi-runtime-compilers-2024`, so it seems like we should use these packages now.

Additionally, one of the packages is not declaring a dependency on `libxml2`, but does not work without it, so we have to install that manually as well.

MISC