### PR TITLE
Release Zivid ROS driver version 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This project adheres to [Semantic Versioning](https://semver.org).
 
+## 2.5.0
+
+* Fixed an issue where the driver when running as a nodelet could not attach to a manager
+  in the global namespace (https://github.com/zivid/zivid-ros/issues/84).
+* Added `capture_and_save` service that captures a frame and saves it to a file.
+* Adjusted some error messages that were assuming all Zivid cameras are connected via USB3.
+* Added CI testing for Zivid SDK versions 2.9 to 2.12.
+
 ## 2.4.0
 
 * Added support for PointXYZ and Range settings that are required for Zivid SDK 2.9.0 and newer

--- a/zivid_camera/package.xml
+++ b/zivid_camera/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>zivid_camera</name>
-  <version>2.4.0</version>
+  <version>2.5.0</version>
   <description>Driver for using the Zivid 3D cameras in ROS.</description>
   <maintainer email="customersuccess@zivid.com">Zivid</maintainer>
   <license>BSD3</license>

--- a/zivid_samples/package.xml
+++ b/zivid_samples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>zivid_samples</name>
-  <version>2.4.0</version>
+  <version>2.5.0</version>
   <description>Contains C++ and Python samples demonstrating
   use of the zivid_camera package.</description>
   <maintainer email="customersuccess@zivid.com">Zivid</maintainer>


### PR DESCRIPTION
This bumps the current package to version 2.5.0, in preparation for upcoming support for ROS2.