### PR TITLE
ROS1: Add readme.md note pointing to 2.14 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ sudo apt-get install -y python3-catkin-tools python3-osrf-pycommon git
 ### Zivid SDK
 
 To use the ROS driver you need to download and install the "Zivid Core" package. Zivid SDK version 2.9.0 to 2.13.1 is
-supported. See [releases](https://github.com/zivid/zivid-ros/releases) for older ROS driver releases
+supported.
+
+See branch [ros1-sdk-2.14.0](https://github.com/zivid/zivid-ros/tree/ros1-sdk-2.14.0) for SDK 2.14 support. Please read top of
+the README.md for limitations in that branch.
+
+See [releases](https://github.com/zivid/zivid-ros/releases) for older ROS driver releases
 that supports older SDK versions.
 
 Follow [this guide][zivid-software-installation-url]


### PR DESCRIPTION
As of now ros1-master doesn't work with SDK 2.14, however we have made a separate branch (removing dynamic_reconfigure settings support) that can be used.

This adds a notice of this to the README to make it easier for people to find.