### PR TITLE
Remove end-of-life ROS2 Iron Irwini from CI testing

### DIFF
--- a/.github/workflows/ROS-commit.yml
+++ b/.github/workflows/ROS-commit.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ['ros:humble-ros-base-jammy', 'ros:iron-ros-core-jammy', 'ros:jazzy-ros-core-noble']
+        os: ['ros:humble-ros-base-jammy', 'ros:jazzy-ros-core-noble']
         compiler: ['g++', 'clang++']
         include:
           - os: 'ros:humble-ros-base-jammy'


### PR DESCRIPTION
Iron Irwini is EOL as of Nov 2024, and was failing in our CI test. Remove Iron from the list of ROS2 distributions we test.