### PR TITLE
Add sRGB color space support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,22 @@ ros2 launch zivid_samples zivid_camera_with_serial_number.launch serial_number:=
 > Read more about [firmware update in our knowledgebase][firmware-update-kb-url].
 > This parameter is optional, and by default it is true.
 
+`color_space` (string, default: "linear_rgb")
+> Specify the color space to use when publishing point clouds and images. Valid values:
+>
+>  - `srgb`: Publish in the sRGB color space. The sRGB color space is suitable for showing an image
+>    on a display for human viewing. It is easier to see details in darker areas of an image in sRGB
+>    than in linear RGB, as more of the dynamic range is dedicated to darker colors. This format is
+>    assumed by default by most monitors and should be used when displaying an image. This option
+>    should be used to match colors to the visualization in Zivid Studio.
+>  - `linear_rgb`: Publish in linear RGB color space. Linear RGB is suitable as input to computer
+>    vision algorithms.
+>
+> In particular, this parameter affects the data published over the [color/image_color](#colorimage_color) and
+> [points/xyzrgba](#pointsxyzrgba) topics. Please see the Zivid knowledge base on
+> [2D Color Spaces and Output Formats](https://support.zivid.com/en/latest/reference-articles/color-spaces-and-output-formats.html)
+> for more details.
+
 ## Configuration
 
 The capture settings used by the `zivid_camera` ROS driver must be configured using YAML,
@@ -711,11 +727,23 @@ See section [Configuration](#configuration) for more details.
 ros2 run zivid_camera zivid_camera --ros-args -p settings_file_path:=/path/to/settings.yml -p settings_2d_file_path:=/path/to/settings2D.yml
 ```
 
+### How to start the driver using the sRGB color space set
+
+```bash
+ros2 run zivid_camera zivid_camera --ros-args -p color_space:=srgb
+```
 ### How to trigger 3D/2D capture via terminal
 
 ```bash
 ros2 service call /capture std_srvs/srv/Trigger
 ros2 service call /capture_2d std_srvs/srv/Trigger
+```
+
+### How to change the color space via terminal
+
+```bash
+ros2 param set zivid_camera color_space srgb
+ros2 param set zivid_camera color_space linear_rgb
 ```
 
 ### How to use a file camera

--- a/zivid_camera/include/zivid_camera/zivid_camera.hpp
+++ b/zivid_camera/include/zivid_camera/zivid_camera.hpp
@@ -48,6 +48,8 @@ class Application;
 class Camera;
 class CameraIntrinsics;
 struct ColorRGBA;
+struct ColorSRGB;
+using ColorRGBA_SRGB = ColorSRGB;
 class Frame;
 template <typename T>
 class Image;
@@ -63,6 +65,11 @@ enum class CameraStatus
   Idle,
   Connected,
   Disconnected
+};
+enum class ColorSpace
+{
+  sRGB,
+  LinearRGB,
 };
 template <typename SettingsType>
 class CaptureSettingsController;
@@ -124,15 +131,20 @@ private:
   void publishPointCloudXYZ(
     const std_msgs::msg::Header & header, const Zivid::PointCloud & point_cloud);
   void publishPointCloudXYZRGBA(
-    const std_msgs::msg::Header & header, const Zivid::PointCloud & point_cloud);
+    const std_msgs::msg::Header & header, const Zivid::PointCloud & point_cloud,
+    ColorSpace color_space);
   void publishColorImage(
     const std_msgs::msg::Header & header,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info,
-    const Zivid::PointCloud & point_cloud);
+    const Zivid::PointCloud & point_cloud, ColorSpace color_space);
   void publishColorImage(
     const std_msgs::msg::Header & header,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info,
     const Zivid::Image<Zivid::ColorRGBA> & image);
+  void publishColorImage(
+    const std_msgs::msg::Header & header,
+    const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info,
+    const Zivid::Image<Zivid::ColorRGBA_SRGB> & image);
   void publishDepthImage(
     const std_msgs::msg::Header & header,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info,
@@ -147,9 +159,11 @@ private:
     const std_msgs::msg::Header & header, std::size_t width, std::size_t height,
     const Zivid::CameraIntrinsics & intrinsics);
   [[noreturn]] void logErrorAndThrowRuntimeException(const std::string & message);
+  ColorSpace colorSpace() const;
 
   friend class ControllerInterface;
 
+  std::map<std::string, ColorSpace> color_space_name_value_map_;
   rclcpp::TimerBase::SharedPtr camera_connection_keepalive_timer_;
   bool use_latched_publisher_for_points_xyz_{false};
   bool use_latched_publisher_for_points_xyzrgba_{false};

--- a/zivid_camera/test/include/test_zivid_camera.hpp
+++ b/zivid_camera/test/include/test_zivid_camera.hpp
@@ -184,6 +184,7 @@ protected:
   static constexpr auto parameter_settings_yaml = "settings_yaml";
   static constexpr auto parameter_settings_2d_file_path = "settings_2d_file_path";
   static constexpr auto parameter_settings_2d_yaml = "settings_2d_yaml";
+  static constexpr auto parameter_color_space = "color_space";
 
   ZividNodeTest(
     FileCameraMode file_camera_mode = FileCameraMode::Default,
@@ -199,6 +200,7 @@ protected:
     setNodeParameter(parameter_settings_yaml, "");
     setNodeParameter(parameter_settings_2d_file_path, "");
     setNodeParameter(parameter_settings_2d_yaml, "");
+    setNodeColorSpaceSRGB();
   }
 
   template <typename SrvType>
@@ -354,6 +356,10 @@ Settings2D:
     setNodeParameter(parameter_settings_file_path, "");
   }
 
+  void setNodeColorSpaceSRGB() { setNodeParameter(parameter_color_space, "srgb"); }
+
+  void setNodeColorSpaceLinearRGB() { setNodeParameter(parameter_color_space, "linear_rgb"); }
+
   template <typename ZividDataModel>
   auto serializeZividDataModel(const ZividDataModel & dm)
   {
@@ -493,9 +499,13 @@ Settings2D:
     ASSERT_EQ(image.is_bigendian, false);
   }
 
+  template <typename ZividColorType>
   void assertSensorMsgsImageContents(
-    const sensor_msgs::msg::Image & image, const Zivid::Array2D<Zivid::ColorRGBA> & expected_rgba)
+    const sensor_msgs::msg::Image & image, const Zivid::Array2D<ZividColorType> & expected_rgba)
   {
+    static_assert(
+      std::is_same_v<ZividColorType, Zivid::ColorRGBA> ||
+      std::is_same_v<ZividColorType, Zivid::ColorRGBA_SRGB>);
     ASSERT_EQ(image.width, expected_rgba.width());
     ASSERT_EQ(image.height, expected_rgba.height());
     for (std::size_t i = 0; i < expected_rgba.size(); i++) {

--- a/zivid_samples/src/sample_capture.cpp
+++ b/zivid_samples/src/sample_capture.cpp
@@ -53,6 +53,24 @@ Settings:
   }
 }
 
+void set_srgb(const std::shared_ptr<rclcpp::Node> & node)
+{
+  auto param_client = std::make_shared<rclcpp::AsyncParametersClient>(node, "zivid_camera");
+  while (!param_client->wait_for_service(std::chrono::seconds(3))) {
+    if (!rclcpp::ok()) {
+      fatal_error(node->get_logger(), "Client interrupted while waiting for service to appear.");
+    }
+    RCLCPP_INFO(node->get_logger(), "Waiting for the parameters client to appear...");
+  }
+
+  auto result = param_client->set_parameters({rclcpp::Parameter("color_space", "srgb")});
+  if (
+    rclcpp::spin_until_future_complete(node, result, std::chrono::seconds(30)) !=
+    rclcpp::FutureReturnCode::SUCCESS) {
+    fatal_error(node->get_logger(), "Failed to set `color_space` parameter");
+  }
+}
+
 auto create_capture_client(std::shared_ptr<rclcpp::Node> & node)
 {
   auto client = node->create_client<std_srvs::srv::Trigger>("capture");
@@ -74,6 +92,7 @@ int main(int argc, char * argv[])
   RCLCPP_INFO(node->get_logger(), "Started the sample_capture node");
 
   set_settings(node);
+  set_srgb(node);
 
   auto capture_client = create_capture_client(node);
   auto trigger_capture = [&]() {

--- a/zivid_samples/src/sample_capture_2d.cpp
+++ b/zivid_samples/src/sample_capture_2d.cpp
@@ -49,6 +49,24 @@ Settings2D:
   }
 }
 
+void set_srgb(const std::shared_ptr<rclcpp::Node> & node)
+{
+  auto param_client = std::make_shared<rclcpp::AsyncParametersClient>(node, "zivid_camera");
+  while (!param_client->wait_for_service(std::chrono::seconds(3))) {
+    if (!rclcpp::ok()) {
+      fatal_error(node->get_logger(), "Client interrupted while waiting for service to appear.");
+    }
+    RCLCPP_INFO(node->get_logger(), "Waiting for the parameters client to appear...");
+  }
+
+  auto result = param_client->set_parameters({rclcpp::Parameter("color_space", "srgb")});
+  if (
+    rclcpp::spin_until_future_complete(node, result, std::chrono::seconds(30)) !=
+    rclcpp::FutureReturnCode::SUCCESS) {
+    fatal_error(node->get_logger(), "Failed to set `color_space` parameter");
+  }
+}
+
 auto create_capture_2d_client(std::shared_ptr<rclcpp::Node> & node)
 {
   auto client = node->create_client<std_srvs::srv::Trigger>("capture_2d");
@@ -70,6 +88,7 @@ int main(int argc, char * argv[])
   RCLCPP_INFO(node->get_logger(), "Started the sample_capture_2d node");
 
   set_settings_2d(node);
+  set_srgb(node);
 
   auto capture_2d_client = create_capture_2d_client(node);
   auto trigger_capture = [&]() {

--- a/zivid_samples/src/sample_capture_and_save.cpp
+++ b/zivid_samples/src/sample_capture_and_save.cpp
@@ -52,6 +52,24 @@ Settings:
   }
 }
 
+void set_srgb(const std::shared_ptr<rclcpp::Node> & node)
+{
+  auto param_client = std::make_shared<rclcpp::AsyncParametersClient>(node, "zivid_camera");
+  while (!param_client->wait_for_service(std::chrono::seconds(3))) {
+    if (!rclcpp::ok()) {
+      fatal_error(node->get_logger(), "Client interrupted while waiting for service to appear.");
+    }
+    RCLCPP_INFO(node->get_logger(), "Waiting for the parameters client to appear...");
+  }
+
+  auto result = param_client->set_parameters({rclcpp::Parameter("color_space", "srgb")});
+  if (
+    rclcpp::spin_until_future_complete(node, result, std::chrono::seconds(30)) !=
+    rclcpp::FutureReturnCode::SUCCESS) {
+    fatal_error(node->get_logger(), "Failed to set `color_space` parameter");
+  }
+}
+
 void capture_and_save(const std::shared_ptr<rclcpp::Node> & node)
 {
   using zivid_interfaces::srv::CaptureAndSave;
@@ -94,6 +112,7 @@ int main(int argc, char * argv[])
   RCLCPP_INFO(node->get_logger(), "Started the sample_capture_and_save node");
 
   set_settings(node);
+  set_srgb(node);
 
   capture_and_save(node);
 

--- a/zivid_samples/src/sample_capture_assistant.cpp
+++ b/zivid_samples/src/sample_capture_assistant.cpp
@@ -62,6 +62,24 @@ void capture(const std::shared_ptr<rclcpp::Node> & node)
   }
 }
 
+void set_srgb(const std::shared_ptr<rclcpp::Node> & node)
+{
+  auto param_client = std::make_shared<rclcpp::AsyncParametersClient>(node, "zivid_camera");
+  while (!param_client->wait_for_service(std::chrono::seconds(3))) {
+    if (!rclcpp::ok()) {
+      fatal_error(node->get_logger(), "Client interrupted while waiting for service to appear.");
+    }
+    RCLCPP_INFO(node->get_logger(), "Waiting for the parameters client to appear...");
+  }
+
+  auto result = param_client->set_parameters({rclcpp::Parameter("color_space", "srgb")});
+  if (
+    rclcpp::spin_until_future_complete(node, result, std::chrono::seconds(30)) !=
+    rclcpp::FutureReturnCode::SUCCESS) {
+    fatal_error(node->get_logger(), "Failed to set `color_space` parameter");
+  }
+}
+
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
@@ -80,6 +98,7 @@ int main(int argc, char * argv[])
     });
 
   capture_assistant_suggest_settings(node);
+  set_srgb(node);
 
   capture(node);
 

--- a/zivid_samples/src/sample_infield_correction.cpp
+++ b/zivid_samples/src/sample_infield_correction.cpp
@@ -93,6 +93,24 @@ bool request_trigger_and_print_response(
   return result->success;
 }
 
+void set_srgb(const std::shared_ptr<rclcpp::Node> & node)
+{
+  auto param_client = std::make_shared<rclcpp::AsyncParametersClient>(node, "zivid_camera");
+  while (!param_client->wait_for_service(std::chrono::seconds(3))) {
+    if (!rclcpp::ok()) {
+      fatal_error(node->get_logger(), "Client interrupted while waiting for service to appear.");
+    }
+    RCLCPP_INFO(node->get_logger(), "Waiting for the parameters client to appear...");
+  }
+
+  auto result = param_client->set_parameters({rclcpp::Parameter("color_space", "srgb")});
+  if (
+    rclcpp::spin_until_future_complete(node, result, std::chrono::seconds(30)) !=
+    rclcpp::FutureReturnCode::SUCCESS) {
+    fatal_error(node->get_logger(), "Failed to set `color_space` parameter");
+  }
+}
+
 std::string capture_status_to_string(
   const std::shared_ptr<rclcpp::Node> & node,
   const zivid_interfaces::srv::InfieldCorrectionCapture::Response & response)
@@ -202,6 +220,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<rclcpp::Node>("sample_infield_correction");
+  set_srgb(node);
 
   const InfieldCorrectionOperation operation =
     get_parameter_enum(*node, "operation", infield_correction_operation_map);


### PR DESCRIPTION
Add a new parameter `color_space` for the zivid camera ROS driver. This can be used to configure which color space point clouds and images are published in.

The default color space is set to sRGB.