### PR TITLE
Update README for SDK 2.14.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,6 @@ AlignEscapedNewlinesLeft: false
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: true


### PR DESCRIPTION
Remove dynamic_reconfigure settings as they are not supported in this branch. Also remove documentation of samples that have been removed.

Finally, remove duplication in the .clang-format file.