### PR TITLE
Add `acquisition_done` topic to zivid_camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,13 @@ Each coordinate is a float value. There are no additional padding floats, so poi
 12 bytes (3*4 bytes). The normals are unit vectors. Note that subscribing to this topic
 will cause some additional processing time for calculating the normals.
 
+### acquisition_done
+
+This topic is published as soon as the camera is done with acquisitions. At this point it
+is safe to move the scene (e.g. robot). This comes before a point cloud or image is necessarily
+available. See the article [Optimize robot cycle times](https://support.zivid.com/en/latest/academy/applications/bin-picking/optimize-robot-cycle-times.html)
+for more information.
+
 ## Configuration
 
 The `zivid_camera` node supports both single-acquisition (2D and 3D) and multi-acquisition

--- a/zivid_camera/include/zivid_camera.h
+++ b/zivid_camera/include/zivid_camera.h
@@ -58,6 +58,7 @@ private:
   bool isConnectedServiceHandler(IsConnected::Request& req, IsConnected::Response& res);
   void publishFrame(const Zivid::Frame& frame);
   Zivid::Frame invokeCaptureAndPublishFrame();
+  bool shouldPublishAcquisitionDone() const;
   bool shouldPublishPointsXYZ() const;
   bool shouldPublishPointsXYZRGBA() const;
   bool shouldPublishColorImg() const;
@@ -65,6 +66,7 @@ private:
   bool shouldPublishSnrImg() const;
   bool shouldPublishNormalsXYZ() const;
   std_msgs::Header makeHeader();
+  void publishAcquisitionDone(const std_msgs::Header& header);
   void publishPointCloudXYZ(const std_msgs::Header& header, const Zivid::PointCloud& point_cloud);
   void publishPointCloudXYZRGBA(const std_msgs::Header& header, const Zivid::PointCloud& point_cloud,
                                 ColorSpace color_space);
@@ -93,12 +95,14 @@ private:
   std::map<std::string, ColorSpace> color_space_name_value_map_;
   ros::Timer camera_connection_keepalive_timer_;
   CameraStatus camera_status_;
+  bool use_latched_publisher_for_acquisition_done_;
   bool use_latched_publisher_for_points_xyz_;
   bool use_latched_publisher_for_points_xyzrgba_;
   bool use_latched_publisher_for_color_image_;
   bool use_latched_publisher_for_depth_image_;
   bool use_latched_publisher_for_snr_image_;
   bool use_latched_publisher_for_normals_xyz_;
+  ros::Publisher acquisition_done_publisher_;
   ros::Publisher points_xyz_publisher_;
   ros::Publisher points_xyzrgba_publisher_;
   image_transport::ImageTransport image_transport_;


### PR DESCRIPTION
When using the Zivid SDK directly there is information in when the capture API returns. This indicates that the camera is done with acquisitions. At this point it is safe to move the scene (e.g. robot). In ROS the capture service wraps the capture call, but also extraction and processing of the point cloud. The same goes for 2D capture.

Use this topic to control when to, e.g., move the robot.