### PR TITLE
Split 2D+3D capture

### DIFF
--- a/continuous-integration/setup/setup_code_analysis.sh
+++ b/continuous-integration/setup/setup_code_analysis.sh
@@ -10,6 +10,14 @@ function apt-yes {
     apt-get --assume-yes "$@"
 }
 
+apt-yes install curl gnupg2 lsb-release || exit $?
+
+curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
+  | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" \
+  > /etc/apt/sources.list.d/ros-latest.list
+
 apt-yes update || exit $?
 apt-yes dist-upgrade || exit $?
 

--- a/zivid_camera/include/zivid_camera.h
+++ b/zivid_camera/include/zivid_camera.h
@@ -76,6 +76,7 @@ private:
   void publishPointCloudXYZ(const std_msgs::Header& header, const Zivid::PointCloud& point_cloud);
   void publishPointCloudXYZRGBA(const std_msgs::Header& header, const Zivid::PointCloud& point_cloud,
                                 ColorSpace color_space);
+  void publishColorImageFromFrame2D(const Zivid::Frame2D& frame2D);
   void publishColorImage(const std_msgs::Header& header, const sensor_msgs::CameraInfoConstPtr& camera_info,
                          const Zivid::PointCloud& point_cloud, ColorSpace color_space);
   void publishColorImage(const std_msgs::Header& header, const sensor_msgs::CameraInfoConstPtr& camera_info,
@@ -90,6 +91,7 @@ private:
   sensor_msgs::CameraInfoConstPtr makeCameraInfo(const std_msgs::Header& header, std::size_t width, std::size_t height,
                                                  const Zivid::CameraIntrinsics& intrinsics);
   ColorSpace colorSpace() const;
+  void updateIntrinsics2D(const Zivid::CameraIntrinsics& intrinsics);
   IntrinsicsSource intrinsicsSource() const;
 
   // using Capture3DSettingsController =
@@ -133,6 +135,7 @@ private:
   Zivid::Camera camera_;
   Zivid::Settings current_settings_;
   Zivid::Settings2D current_settings_2d_;
+  Zivid::CameraIntrinsics current2Dintrinsics_;
 
   std::string frame_id_;
   unsigned int header_seq_;

--- a/zivid_camera/src/node.cpp
+++ b/zivid_camera/src/node.cpp
@@ -37,7 +37,11 @@ int main(int argc, char** argv)
     }
 
     ROS_INFO("Successfully loaded nodelet '%s'", nodelet_name);
-    ros::spin();
+    // ros::spin();
+    ros::AsyncSpinner spinner(3);  // Use 2 threads or more, depends on workload
+    spinner.start();
+
+    ros::waitForShutdown();
     return EXIT_SUCCESS;
   }
   catch (const std::exception& e)

--- a/zivid_samples/settings/camera_settings.yml
+++ b/zivid_samples/settings/camera_settings.yml
@@ -1,48 +1,100 @@
-__version__:
-  serializer: 1
-  data: 10
+__version__: 27
 Settings:
-  Acquisitions:
-    - Acquisition:
-        Aperture: 5.66
-        Brightness: 1.5
-        ExposureTime: 6500
-        Gain: 1
-  Diagnostics:
-    Enabled: no
-  Experimental:
-    Engine: phase
-  Processing:
+    Acquisitions:
+        - Acquisition:
+              Aperture: 2.83
+              Brightness: 1.8
+              ExposureTime: 40000
+              Gain: 1
+        - Acquisition:
+              Aperture: 2.83
+              Brightness: 1.8
+              ExposureTime: 40000
+              Gain: 1
     Color:
-      Balance:
-        Blue: 1
-        Green: 1
-        Red: 1
-      Experimental:
-        ToneMapping:
-          Enabled: hdrOnly
-      Gamma: 1
-    Filters:
-      Experimental:
-        ContrastDistortion:
-          Correction:
+        __version__: 7
+        Settings2D:
+            Acquisitions:
+                - Acquisition:
+                      Aperture: 4.0
+                      Brightness: 1.8
+                      ExposureTime: 2000
+                      Gain: 1
+            Processing:
+                Color:
+                    Balance:
+                        Blue: 1
+                        Green: 1
+                        Red: 1
+                    Experimental:
+                        Mode: automatic
+                    Gamma: 1
+            Sampling:
+                Color: rgb
+                Pixel: all
+    Diagnostics:
+        Enabled: no
+    Engine: stripe
+    Processing:
+        Color:
+            Balance:
+                Blue: 1
+                Green: 1
+                Red: 1
+            Experimental:
+                Mode: automatic
+            Gamma: 1
+        Filters:
+            Cluster:
+                Removal:
+                    Enabled: yes
+                    MaxNeighborDistance: 7
+                    MinArea: 500
+            Experimental:
+                ContrastDistortion:
+                    Correction:
+                        Enabled: yes
+                        Strength: 0.3
+                    Removal:
+                        Enabled: no
+                        Threshold: 0.3
+            Hole:
+                Repair:
+                    Enabled: yes
+                    HoleSize: 0.2
+                    Strictness: 2
+            Noise:
+                Removal:
+                    Enabled: yes
+                    Threshold: 3
+                Repair:
+                    Enabled: no
+                Suppression:
+                    Enabled: no
+            Outlier:
+                Removal:
+                    Enabled: yes
+                    Threshold: 20
+            Reflection:
+                Removal:
+                    Enabled: yes
+                    Mode: global
+            Smoothing:
+                Gaussian:
+                    Enabled: yes
+                    Sigma: 4
+        Resampling:
+            Mode: __not_set__
+    RegionOfInterest:
+        Box:
             Enabled: no
-            Strength: 0.4
-          Removal:
+            Extents: [-10, 100]
+            PointA: [0, 0, 0]
+            PointB: [0, 0, 0]
+            PointO: [0, 0, 0]
+        Depth:
             Enabled: no
-            Threshold: 0.5
-      Noise:
-        Removal:
-          Enabled: yes
-          Threshold: 7
-      Outlier:
-        Removal:
-          Enabled: yes
-          Threshold: 5
-      Reflection:
-        Removal:
-          Enabled: no
-      Smoothing:
-        Gaussian:
-          Enabled: no
-          Sigma: 1.5
+            Range: [300, 1300]
+    Sampling:
+        Color: rgb
+        Pixel: all

--- a/zivid_samples/src/sample_capture_with_settings_from_yml.cpp
+++ b/zivid_samples/src/sample_capture_with_settings_from_yml.cpp
@@ -2,6 +2,7 @@
 #include <zivid_camera/LoadSettingsFromFile.h>
 #include <dynamic_reconfigure/Reconfigure.h>
 #include <dynamic_reconfigure/client.h>
+#include <sensor_msgs/Image.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <ros/ros.h>
 #include <ros/package.h>
@@ -19,6 +20,21 @@ namespace
 {
 const ros::Duration default_wait_duration{ 30 };
 
+auto waitForPublisher = [](const ros::Subscriber& sub, ros::Duration timeout) {
+  ros::Time start = ros::Time::now();
+  ros::Rate rate(10);
+  while ((ros::Time::now() - start) < timeout)
+  {
+    if (sub.getNumPublishers() > 0)
+    {
+      return true;
+    }
+    ros::spinOnce();
+    rate.sleep();
+  }
+  return false;
+};
+
 void capture()
 {
   ROS_INFO("Calling capture service");
@@ -26,6 +42,20 @@ void capture()
   CHECK(ros::service::call("/zivid_camera/capture", capture));
 }
 
+void on_points(const sensor_msgs::PointCloud2ConstPtr&)
+{
+  ROS_INFO("PointCloud received");
+}
+
+void on_image_color(const sensor_msgs::ImageConstPtr&)
+{
+  ROS_INFO("2D color image received");
+}
+
+void on_acquisition_done(const std_msgs::HeaderConstPtr& header)
+{
+  ROS_INFO("Acquisition done: %s", header->frame_id.c_str());
+}
 }  // namespace
 
 int main(int argc, char** argv)
@@ -37,8 +67,15 @@ int main(int argc, char** argv)
 
   CHECK(ros::service::waitForService("/zivid_camera/capture", default_wait_duration));
 
-  ros::AsyncSpinner spinner(1);
+  ros::AsyncSpinner spinner(3);
   spinner.start();
+
+  auto points_sub = n.subscribe("/zivid_camera/points/xyzrgba", 1, on_points);
+  CHECK(waitForPublisher(points_sub, default_wait_duration));
+  auto image_color_sub = n.subscribe("/zivid_camera/color/image_color", 1, on_image_color);
+  CHECK(waitForPublisher(image_color_sub, default_wait_duration));
+  auto acquisition_done_sub = n.subscribe("/zivid_camera/acquisition_done", 1, on_acquisition_done);
+  CHECK(waitForPublisher(acquisition_done_sub, default_wait_duration));
 
   std::string samples_path = ros::package::getPath("zivid_samples");
   std::string settings_path = samples_path + "/settings/camera_settings.yml";


### PR DESCRIPTION
Zivid SDK will capture both 2D and 3D if `Zivid::Settings` contain `Zivid::Settings::color`. However, it will not return from the capture until both 2D and 3D has been acquired. In order to get 2D data as fast as possible we split the capture into two separate calls. This allows us to publish the 2D color image as soon as it is ready.

This has no impact on the subscriber, other than in which order the topics arrive.

Before: `acquisition_done` -> `color/image_color` -> `points/xyz`
After: `color/image_color` -> `acquisition_done` -> `points/xyz`

The order of `color/image_color` and `acquisition_done` depends on the 3D acquisition settings and the processing speed of 2D color.

Note! Previously the resolution of the 2D image, when published as part of the 3D capture service, was tied to the 3D point cloud. That also applied to intrinsics. Now it will only reflect the 2D settings. In other words, in order to have 1-to-1 mapping between the 2D color image and the point cloud one must set the same Zivid::Settings::Sampling in both. In other words:

```yml
Settings:
    Color:
        __version__: 7
        Settings2D:
            Sampling:
                Color: rgb
                Pixel: all
 ```
must equal

```yml
Settings:
    Sampling:
        Color: rgb
        Pixel: all
```
in order to have the same resolution on both.

This also means that there is no path to publish the point cloud
resolution mapped color image, which was previously published
even when `Zivid::Settings2D::Sampling` != `Zivid::Settings::Sampling`

In this commit we also cache the intrinsics in order to unblock
publishing 2D color image. This is because calculating intrinsics
requires the camera.