### PR TITLE
Share Application in ZividCamera

### DIFF
--- a/zivid_camera/include/zivid_camera/zivid_camera.hpp
+++ b/zivid_camera/include/zivid_camera/zivid_camera.hpp
@@ -88,7 +88,10 @@ class ControllerInterface;
 class ZividCamera : public rclcpp::Node
 {
 public:
-  ZIVID_CAMERA_ROS_PUBLIC ZividCamera(const rclcpp::NodeOptions & options);
+  ZIVID_CAMERA_ROS_PUBLIC explicit ZividCamera(const rclcpp::NodeOptions & options);
+  ZIVID_CAMERA_ROS_PUBLIC ZividCamera(
+    const std::string & node_name, const std::string & ns, const rclcpp::NodeOptions & options,
+    std::shared_ptr<Zivid::Application> application);
   ~ZividCamera() override;
   ZIVID_CAMERA_ROS_PUBLIC Zivid::Application & zividApplication();
 
@@ -206,7 +209,7 @@ private:
   std::unique_ptr<HandEyeCalibrationController> hand_eye_calibration_controller_;
   std::unique_ptr<ProjectionController> projection_controller_;
 
-  std::unique_ptr<Zivid::Application> zivid_;
+  std::shared_ptr<Zivid::Application> zivid_;
   CameraStatus camera_status_{CameraStatus::Idle};
   std::unique_ptr<CaptureSettingsController<Zivid::Settings>> settings_controller_;
   std::unique_ptr<CaptureSettingsController<Zivid::Settings2D>> settings_2d_controller_;


### PR DESCRIPTION
This PR adds the possibility to construct a `ZividCamera` with an already existing `Application` and a custom node name/namespace.

This is helpful for having additional ROS helper nodes around `ZividCamera`, which also require an `Application` that can only be instantiated once.