### PR TITLE
Configure Dependabot for GitHub Actions and update checkout action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ROS-commit.yml
+++ b/.github/workflows/ROS-commit.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           lfs: false
       - name: Run code_analysis.sh
@@ -55,7 +55,7 @@ jobs:
             compiler: 'clang++-18'
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           lfs: false
       - name: Build and Test
@@ -79,7 +79,7 @@ jobs:
         ros-distro: ['ros:humble-ros-base-jammy']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           lfs: false
       - name: Build and Test

--- a/.github/workflows/ROS-commit.yml
+++ b/.github/workflows/ROS-commit.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: false
       - name: Run code_analysis.sh
@@ -79,7 +79,7 @@ jobs:
         ros-distro: ['ros:humble-ros-base-jammy']
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: false
       - name: Build and Test

--- a/.github/workflows/ROS-commit.yml
+++ b/.github/workflows/ROS-commit.yml
@@ -7,6 +7,9 @@ on:
   schedule:      # Scheduled trigger runs on the latest commit on the default branch.
     - cron:  '0 22 * * *'
 
+permissions:
+  contents: read
+
 env:
   NEWEST_ZIVID_VERSION: '2.17.0+5fc9f05e-1'
 

--- a/.github/workflows/ROS-commit.yml
+++ b/.github/workflows/ROS-commit.yml
@@ -58,7 +58,7 @@ jobs:
             compiler: 'clang++-18'
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: false
       - name: Build and Test


### PR DESCRIPTION
This pull request introduces configuration improvements to GitHub workflows and adds automated dependency management for GitHub Actions. The main changes include updating the `actions/checkout` action to a specific commit hash for improved security, explicitly setting workflow permissions, and adding a Dependabot configuration file for automated updates.

**Workflow security and configuration improvements:**

* Updated the `actions/checkout` action in `.github/workflows/ROS-commit.yml` to use a specific commit hash (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`), replacing the previous version reference (`v2`). This change is applied in multiple jobs for enhanced security and reproducibility. [[1]](diffhunk://#diff-1818a737ee480846f15bea51bf851c97e63682a525b43c0a612129031cbe38fdL19-R22) [[2]](diffhunk://#diff-1818a737ee480846f15bea51bf851c97e63682a525b43c0a612129031cbe38fdL58-R61) [[3]](diffhunk://#diff-1818a737ee480846f15bea51bf851c97e63682a525b43c0a612129031cbe38fdL82-R85)
* Added explicit `permissions` (set to `contents: read`) to the workflow file `.github/workflows/ROS-commit.yml` to follow GitHub's best practices for least privilege.

**Automated dependency management:**

* Added a new `.github/dependabot.yml` file to enable Dependabot for GitHub Actions, scheduling weekly checks for updates and setting a cooldown period of 7 days between updates.

fixes #162 